### PR TITLE
global: config loading from entry point

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,6 +34,9 @@ Loaders
 .. automodule:: invenio_config.env
    :members:
 
+.. automodule:: invenio_config.entrypoint
+  :members:
+
 .. automodule:: invenio_config.folder
    :members:
 
@@ -45,4 +48,3 @@ Utilities
 
 .. automodule:: invenio_config.utils
    :members:
-

--- a/invenio_config/__init__.py
+++ b/invenio_config/__init__.py
@@ -34,6 +34,9 @@ The following configuration loaders exists:
   configuration values are set.
 - :py:data:`invenio_config.module.InvenioConfigModule` - for loading
   configuration from a Python module.
+- :py:data:`invenio_config.entrypoint.InvenioConfigEntryPointModule` - for
+  loading configuration from a Python module specified by an entry point (by
+  default ``invenio_config.module``).
 - :py:data:`invenio_config.folder.InvenioConfigInstanceFolder` - for loading
   configuration from ``cfg`` file in an instance folder.
 - :py:data:`invenio_config.env.InvenioConfigEnvironment` - for loading
@@ -103,6 +106,14 @@ Here is an example of a configuration object:
 >>> app.config['EXAMPLE']
 'module'
 
+Entry point
+~~~~~~~~~~~
+The entry point loader works similar to the module loader, it just loads the
+config module from the entry point ``invenio_config.module``:
+
+>>> from invenio_config import InvenioConfigEntryPointModule
+>>> config_ep = InvenioConfigEntryPointModule(app=app)
+
 Instance Folder
 ~~~~~~~~~~~~~~~
 The runtime configuration should be stored in a separate file, ideally located
@@ -138,11 +149,12 @@ The Invenio-Config comes with an opinionated way of loading configuration,
 that combines loaders in predictable way. You can use
 :func:`invenio_config.utils.create_config_loader` if you would like to:
 
-  1. Load configuration from ``config`` module if provided as argument.
-  2. Load configuration from the instance folder:
+  1. Load configuration from ``invenio_config.module`` entry point group.
+  2. Load configuration from ``config`` module if provided as argument.
+  3. Load configuration from the instance folder:
      ``<app.instance_path>/<app.name>.cfg``.
-  3. Load configuration keyword arguments provided.
-  4. Load configuration from environment variables with the prefix
+  4. Load configuration keyword arguments provided.
+  5. Load configuration from environment variables with the prefix
      ``env_prefix``.
 
 >>> from invenio_config import create_config_loader
@@ -162,12 +174,14 @@ from .default import InvenioConfigDefault
 from .env import InvenioConfigEnvironment
 from .folder import InvenioConfigInstanceFolder
 from .module import InvenioConfigModule
+from .entrypoint import InvenioConfigEntryPointModule
 from .utils import create_conf_loader, create_config_loader
 from .version import __version__
 
 __all__ = (
     '__version__',
     'InvenioConfigDefault',
+    'InvenioConfigEntryPointModule',
     'InvenioConfigEnvironment',
     'InvenioConfigInstanceFolder',
     'InvenioConfigModule',

--- a/invenio_config/entrypoint.py
+++ b/invenio_config/entrypoint.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Invenio entry point module configuration."""
+
+from __future__ import absolute_import, print_function
+
+import warnings
+
+import pkg_resources
+
+
+class InvenioConfigEntryPointModule(object):
+    """Load configuration from module defined by entry point.
+
+    .. versionadded:: 1.0.0
+    """
+
+    def __init__(self, app=None, entry_point_group='invenio_config.module'):
+        """Initialize extension."""
+        self.entry_point_group = entry_point_group
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Initialize Flask application."""
+        if self.entry_point_group:
+            for ep in pkg_resources.iter_entry_points(self.entry_point_group):
+                app.config.from_object(ep.load())

--- a/invenio_config/utils.py
+++ b/invenio_config/utils.py
@@ -27,6 +27,7 @@
 from __future__ import absolute_import, print_function
 
 from .default import InvenioConfigDefault
+from .entrypoint import InvenioConfigEntryPointModule
 from .env import InvenioConfigEnvironment
 from .folder import InvenioConfigInstanceFolder
 from .module import InvenioConfigModule
@@ -41,11 +42,12 @@ def create_config_loader(config=None, env_prefix='APP'):
     This default configuration loader will load configuration in the following
     order:
 
-        1. Load configuration from ``config`` module if provided as argument.
-        2. Load configuration from the instance folder:
+        1. Load configuration from ``invenio_config.module`` entry point group.
+        2. Load configuration from ``config`` module if provided as argument.
+        3. Load configuration from the instance folder:
            ``<app.instance_path>/<app.name>.cfg``.
-        3. Load configuration keyword arguments provided.
-        4. Load configuration from environment variables with the prefix
+        4. Load configuration keyword arguments provided.
+        5. Load configuration from environment variables with the prefix
            ``env_prefix``.
 
     If no secret key has been set a warning will be issued.
@@ -60,6 +62,7 @@ def create_config_loader(config=None, env_prefix='APP'):
     .. versionadded:: 1.0.0
     """
     def _config_loader(app, **kwargs_config):
+        InvenioConfigEntryPointModule(app=app)
         if config:
             InvenioConfigModule(app=app, module=config)
         InvenioConfigInstanceFolder(app=app)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
     'isort>=4.2.2',
+    'mock>=2.0.0',
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',


### PR DESCRIPTION
* Adds support for loading a configuration from a Python module
  specified by an entry point group.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>