### PR TITLE
docs: describe complex variables in environment

### DIFF
--- a/invenio_config/__init__.py
+++ b/invenio_config/__init__.py
@@ -127,6 +127,16 @@ define a variable prefix used by the loader.
 >>> app.config['EXAMPLE']
 'environment'
 
+You can also set more complex Python literal variables (e.g. dictionaries or
+lists):
+
+>>> os.environ['MYAPP_COMPLEX'] = "{'items': [{'num': 42}, {'foo': 'bar'}]}"
+>>> # ...or export MYAPP_COMPLEX="{'items': [{'num': 42}, {'foo': 'bar'}]}"
+>>> config_environment = InvenioConfigEnvironment(app=app, prefix='MYAPP_')
+>>> app.config['COMPLEX']
+{'items': [{'num': 42}, {'foo': 'bar'}]}
+
+
 Factory Pattern
 ---------------
 The Invenio-Config comes with an opinionated way of loading configuration,

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,8 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
+pep8ignore =
+    __init__.py E501
+    docs/conf.py ALL
 addopts = --pep8 --ignore=docs --cov=invenio_config --cov-report=term-missing
+testpaths = docs tests invenio_config

--- a/tests/test_invenio_config.py
+++ b/tests/test_invenio_config.py
@@ -121,9 +121,13 @@ def test_env():
 
     os.environ["MYPREFIX_TESTVAR"] = "True"
     os.environ["MYPREFIX_JUSTASTRING"] = "This is just a string"
+    os.environ["MYPREFIX_COMPLEX_DICT"] = (
+        "{'complex': {'python': 'dict'}, 'with': ['list', 'and', 1234]}")
     InvenioConfigEnvironment(app, prefix="MYPREFIX_")
     assert app.config.get('TESTVAR') is True
     assert app.config.get('JUSTASTRING') == "This is just a string"
+    assert app.config.get('COMPLEX_DICT') == \
+        {'complex': {'python': 'dict'}, 'with': ['list', 'and', 1234]}
 
 
 @patch('pkg_resources.iter_entry_points', _mock_ep([


### PR DESCRIPTION
* Describes how Python literals can be used as config variables.
  (closes #30)