### PR TITLE
bugfix: add invenio_config to testpaths in tool:pytest configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,5 +53,5 @@ ignore =
 
 [tool:pytest]
 addopts = --black --isort --pydocstyle --doctest-glob="*.rst" --doctest-modules --cov=invenio_config --cov-report=term-missing
-testpaths = tests
+testpaths = tests invenio_config
 filterwarnings = ignore::pytest.PytestDeprecationWarning


### PR DESCRIPTION
otherwise e.g. black is not tested in this directory
